### PR TITLE
Add simple HTTP SSE option

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,8 @@ CLICKHOUSE_PASSWORD=clickhouse
 3. Run `uv sync` to install the dependencies. To install `uv` follow the instructions [here](https://docs.astral.sh/uv/). Then do `source .venv/bin/activate`.
 
 4. For easy testing, you can run `mcp dev mcp_clickhouse/mcp_server.py` to start the MCP server.
+   To expose an HTTP SSE interface at port 8000 run:
+   `mcp dev mcp_clickhouse/mcp_server.py -- --http-port 8000`
 
 ### Environment Variables
 

--- a/mcp_clickhouse/http_sse_server.py
+++ b/mcp_clickhouse/http_sse_server.py
@@ -1,0 +1,50 @@
+import json
+import urllib.parse
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+from .mcp_server import list_databases, list_tables, run_select_query
+
+
+class SSEHandler(BaseHTTPRequestHandler):
+    """Simple HTTP handler that streams responses using the SSE protocol."""
+
+    def do_GET(self):
+        parsed = urllib.parse.urlparse(self.path)
+        path = parsed.path
+        params = urllib.parse.parse_qs(parsed.query)
+
+        if path == "/list_databases":
+            result = list_databases()
+        elif path == "/list_tables":
+            database = params.get("database", [None])[0]
+            like = params.get("like", [None])[0]
+            not_like = params.get("not_like", [None])[0]
+            if not database:
+                self.send_error(400, "database parameter required")
+                return
+            result = list_tables(database, like=like, not_like=not_like)
+        elif path == "/run_select_query":
+            query = params.get("query", [None])[0]
+            if not query:
+                self.send_error(400, "query parameter required")
+                return
+            result = run_select_query(query)
+        else:
+            self.send_error(404, "Not Found")
+            return
+
+        self.send_response(200)
+        self.send_header("Content-type", "text/event-stream")
+        self.send_header("Cache-Control", "no-cache")
+        self.end_headers()
+        payload = json.dumps(result)
+        self.wfile.write(f"data: {payload}\n\n".encode("utf-8"))
+
+
+def start_sse_server(port: int = 8000) -> None:
+    """Start the HTTP SSE server on the given port."""
+    server = HTTPServer(("0.0.0.0", port), SSEHandler)
+    try:
+        server.serve_forever()
+    finally:
+        server.server_close()

--- a/mcp_clickhouse/main.py
+++ b/mcp_clickhouse/main.py
@@ -1,7 +1,26 @@
+import argparse
+
 from .mcp_server import mcp
+from .http_sse_server import start_sse_server
 
 
 def main():
+    parser = argparse.ArgumentParser(description="Run the ClickHouse MCP server")
+    parser.add_argument(
+        "--http-port",
+        type=int,
+        help="If set, run an additional HTTP SSE server on this port",
+    )
+    args = parser.parse_args()
+
+    if args.http_port:
+        import threading
+
+        server_thread = threading.Thread(
+            target=start_sse_server, args=(args.http_port,), daemon=True
+        )
+        server_thread.start()
+
     mcp.run()
 
 


### PR DESCRIPTION
## Summary
- add a minimal HTTP SSE server implementation
- run SSE server when `--http-port` is provided
- document new option in README

## Testing
- `uv run ruff check .` *(fails: Failed to fetch)*
- `uv run pytest -q` *(fails: Failed to fetch)*

------
https://chatgpt.com/codex/tasks/task_b_68451857e5b48320a23a0f2af7a94971